### PR TITLE
Fix binary availabilities

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -111,6 +111,11 @@ else
   rm -f *.* | indent
   # Package the compiled binaries
   tar -zcvf "$PRECOMPILED_PACKAGE_FILENAME" -C $TARGET_DIR . | indent
+
+  echo "Displaying the version of pdftoppm"
+  echo $PATH
+  which pdftoppm
+  pdftoppm -v 
 fi
 
 # Subsequent buildpacks need to know where the libraries are, based on the

--- a/bin/compile
+++ b/bin/compile
@@ -110,7 +110,7 @@ else
   # Remove old cached precompiled packages
   rm -f *.* | indent
   # Package the compiled binaries
-  tar -zcvf "$PRECOMPILED_PACKAGE_FILENAME" -C $TARGET_DIR . | indent  
+  tar -zcvf "$PRECOMPILED_PACKAGE_FILENAME" -C $TARGET_DIR . | indent
 fi
 
 # Subsequent buildpacks need to know where the libraries are, based on the
@@ -126,4 +126,3 @@ mkdir -p $BUILD_DIR/.profile.d
 exports "\$HOME/vendor/poppler" > $BUILD_DIR/.profile.d/000_poppler.sh
 
 echo ""
-

--- a/bin/compile
+++ b/bin/compile
@@ -61,7 +61,7 @@ else
   wget --no-verbose --no-clobber https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz
   tar -xf flex-2.6.4.tar.gz --skip-old-files
   pushd flex-2.6.4
-    ./configure --prefix="${WORKING_DIR}/flex"
+    ./configure --prefix="${WORKING_DIR}/flex" CFLAGS='-g -O2 -D_GNU_SOURCE'
     make
     make install
   popd
@@ -126,3 +126,4 @@ mkdir -p $BUILD_DIR/.profile.d
 exports "\$HOME/vendor/poppler" > $BUILD_DIR/.profile.d/000_poppler.sh
 
 echo ""
+

--- a/bin/compile
+++ b/bin/compile
@@ -110,12 +110,7 @@ else
   # Remove old cached precompiled packages
   rm -f *.* | indent
   # Package the compiled binaries
-  tar -zcvf "$PRECOMPILED_PACKAGE_FILENAME" -C $TARGET_DIR . | indent
-
-  echo "Displaying the version of pdftoppm"
-  echo $PATH
-  which pdftoppm
-  pdftoppm -v 
+  tar -zcvf "$PRECOMPILED_PACKAGE_FILENAME" -C $TARGET_DIR . | indent  
 fi
 
 # Subsequent buildpacks need to know where the libraries are, based on the

--- a/bin/release
+++ b/bin/release
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
 echo "---"
-echo "addons:"
 echo "config_vars:"
 echo "  PATH: $PATH:/app/vendor/poppler/bin"
-echo "default_process_types:"

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo "---"
+echo "addons:"
+echo "config_vars:"
+echo "  PATH: $PATH:/app/vendor/poppler/bin"
+echo "default_process_types:"


### PR DESCRIPTION
The [pdftoimage](https://github.com/robflynn/pdftoimage) ruby gem wasn't able to find the `pdftoppm`binary. 
Based on the Heroku documentation, a buildpack can modify the $PATH variable from the `bin/release` script.